### PR TITLE
Remove redundant CSS and added inline styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,12 +19,6 @@ a:hover {
   color: #CBF2FF;
 }
 
-.email, .button {
-  height: 40px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-}
-
 .sky {
   background-color: #CBF2FF;
   padding-top: 100px;
@@ -54,11 +48,10 @@ input {
   height: 15em;
 }
 
-@media only screen and (min-width: 1024px) {
+@media only screen and (min-width: 768px) {
 
   .field {
     overflow: hidden;
-    padding-right: .5em;
     display: flex;
     flex-direction: row;
   }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
           <form action="//bitca.us14.list-manage.com/subscribe/post?u=8d420d7289f5918838f6ce9e8&amp;id=8d4989f015" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
             <div id="mc_embed_signup_scroll">
               <div class="field">
-                <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" style="color:#7F6C5F" placeholder="email address" required>
+                <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" style="color:#7F6C5F; width: 100%; font-family: 'Avenir', Arial, sans-serif;" placeholder="email address" required>
                 <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                 <div class="clear">
                   <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background-color:#FF6F3F">


### PR DESCRIPTION
Found the issue as to why my local view was different from the online view. Locally, I did not have mailchimp's CSS files so after tinkering with the production version, I have made changes that removed some redundant CSS that was overridden by mailchimp's stylesheet. I also added inline styling to maintain the width of the input field that was off center on larger resolutions and adjusted the min-width to switch styles. Please look it over to make sure I haven't made any more errors!