### PR TITLE
Fix initial image loading

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,4 @@
 $(document).ready(function(){
-  adjustLogo();
 	$('#nav-icon2').click(function(){
 		$(this).toggleClass('open');
     $( ".menu" ).slideToggle( "slow");
@@ -7,6 +6,7 @@ $(document).ready(function(){
   $( ".menu" ).hide();
 });
 $(window).on('resize', adjustLogo);
+$(window).on('load', adjustLogo);
 function adjustLogo(){
   var half = window.innerHeight/2;
   var margin = $("#nav-bar-wrapper").outerHeight() - 


### PR DESCRIPTION
This waits until the window and images have loaded to adjust the logo. It seems to fix an issue I get when loading bitca.mp for the first time where the FAQ, Sponsors, and Contact buttons overlap with "Bitcamp is a place of exploration...".